### PR TITLE
move content type upper in the file

### DIFF
--- a/lib/write_xlsx/package/packager.rb
+++ b/lib/write_xlsx/package/packager.rb
@@ -34,6 +34,7 @@ module Writexlsx
       #
       def create_package
         write_worksheet_files
+        write_content_types_file
         write_chartsheet_files
         write_workbook_file
         write_chart_files
@@ -44,7 +45,6 @@ module Writexlsx
         write_shared_strings_file
         write_app_file
         write_core_file
-        write_content_types_file
         write_styles_file
         write_theme_file
         write_root_rels_file


### PR DESCRIPTION
This is due to an issue to identify XLSX files with mime_magic. That gem looks for the content type in the file, but the bigger the file is, the deeper that information is pushed down inside, so as the file grows, it might get identified as zip.